### PR TITLE
Blueprint changes

### DIFF
--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,8 @@
+{
+  "extends": "../.jshintrc",
+  "predef": [
+    "console"
+  ],
+  "strict": false,
+  "node": true
+}

--- a/blueprints/emberfire/files/app/adapters/application.js
+++ b/blueprints/emberfire/files/app/adapters/application.js
@@ -1,0 +1,7 @@
+import config from '../config/environment';
+import Firebase from 'firebase';
+import FirebaseAdapter from 'emberfire/adapters/firebase';
+
+export default FirebaseAdapter.extend({
+  firebase: new Firebase(config.firebase)
+});

--- a/blueprints/emberfire/files/config/environment.js
+++ b/blueprints/emberfire/files/config/environment.js
@@ -1,0 +1,48 @@
+/* jshint node: true */
+
+module.exports = function(environment) {
+  var ENV = {
+    modulePrefix: '<%= modulePrefix %>',
+    environment: environment,
+    baseURL: '/',
+    locationType: 'auto',
+    firebase: '<%= firebaseUrl %>',
+    EmberENV: {
+      FEATURES: {
+        // Here you can enable experimental features on an ember canary build
+        // e.g. 'with-controller': true
+      }
+    },
+
+    APP: {
+      // Here you can pass flags/options to your application instance
+      // when it is created
+    }
+  };
+
+  if (environment === 'development') {
+    // ENV.APP.LOG_RESOLVER = true;
+    // ENV.APP.LOG_ACTIVE_GENERATION = true;
+    // ENV.APP.LOG_TRANSITIONS = true;
+    // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
+    // ENV.APP.LOG_VIEW_LOOKUPS = true;
+  }
+
+  if (environment === 'test') {
+    // Testem prefers this...
+    ENV.baseURL = '/';
+    ENV.locationType = 'none';
+
+    // keep test console output quieter
+    ENV.APP.LOG_ACTIVE_GENERATION = false;
+    ENV.APP.LOG_VIEW_LOOKUPS = false;
+
+    ENV.APP.rootElement = '#ember-testing';
+  }
+
+  if (environment === 'production') {
+
+  }
+
+  return ENV;
+};

--- a/blueprints/emberfire/index.js
+++ b/blueprints/emberfire/index.js
@@ -1,4 +1,3 @@
-/* jshint node: true */
 'use strict';
 
 module.exports = {

--- a/blueprints/emberfire/index.js
+++ b/blueprints/emberfire/index.js
@@ -1,6 +1,8 @@
 /* jshint node: true */
 'use strict';
 
+var SilentError = require('ember-cli/lib/errors/silent');
+
 module.exports = {
   normalizeEntityName: function() {
     // this prevents an error when the entityName is
@@ -8,7 +10,24 @@ module.exports = {
     // to us
   },
 
+  availableOptions: [
+    { name: 'url', type: String }
+  ],
+
+  locals: function(options) {
+    if (!options.url) {
+      throw new SilentError('you need to provide a firebase url e.g. ember generate emberfire --url=https://YOUR-FIREBASE-NAME.firebaseio.com/')
+    }
+
+    return {
+      modulePrefix: options.project.pkg.name,
+      firebaseUrl: options.url
+    }
+  },
+
   afterInstall: function() {
-    return this.addBowerPackageToProject('emberfire', '~0.0.0');
+    return this.addBowerPackagesToProject([
+        {name: 'emberfire', target: "~0.0.0"}
+    ]);
   }
 };

--- a/blueprints/emberfire/index.js
+++ b/blueprints/emberfire/index.js
@@ -1,8 +1,6 @@
 /* jshint node: true */
 'use strict';
 
-var SilentError = require('ember-cli/lib/errors/silent');
-
 module.exports = {
   normalizeEntityName: function() {
     // this prevents an error when the entityName is
@@ -15,14 +13,10 @@ module.exports = {
   ],
 
   locals: function(options) {
-    if (!options.url) {
-      throw new SilentError('you need to provide a firebase url e.g. ember generate emberfire --url=https://YOUR-FIREBASE-NAME.firebaseio.com/')
-    }
-
     return {
       modulePrefix: options.project.pkg.name,
-      firebaseUrl: options.url
-    }
+      firebaseUrl: options.url || 'https://YOUR-FIREBASE-NAME.firebaseio.com/'
+    };
   },
 
   afterInstall: function() {

--- a/blueprints/firebase-adapter/files/app/adapters/__name__.js
+++ b/blueprints/firebase-adapter/files/app/adapters/__name__.js
@@ -1,5 +1,7 @@
-<%= importStatements %>
+import config from '../config/environment';
+import Firebase from 'firebase';
+import FirebaseAdapter from 'emberfire/adapters/firebase';
 
-export default <%= baseClass %>.extend({
+export default FirebaseAdapter.extend({
   firebase: new Firebase(<%= firebaseUrl %>)
 });

--- a/blueprints/firebase-adapter/files/app/adapters/__name__.js
+++ b/blueprints/firebase-adapter/files/app/adapters/__name__.js
@@ -1,0 +1,5 @@
+<%= importStatements %>
+
+export default <%= baseClass %>.extend({
+  firebase: new Firebase(<%= firebaseUrl %>)
+});

--- a/blueprints/firebase-adapter/index.js
+++ b/blueprints/firebase-adapter/index.js
@@ -1,0 +1,25 @@
+var inflection = require('inflection');
+
+module.exports = {
+  description: 'Generates an firebase adapter.',
+
+  locals: function(options) {
+    var firebaseUrl     = 'config.firebase';
+    var adapterName     = options.entity.name;
+    var baseClass       = 'FirebaseAdapter';
+    var importStatements =
+      'import config from \'../config/environment\';\n' +
+      'import Firebase from \'firebase\';\n' +
+      'import FirebaseAdapter from \'emberfire/adapters/firebase\';'
+
+    if (adapterName !== 'application') {
+      firebaseUrl = "config.firebase + '/" + inflection.pluralize(adapterName) + "'";
+    }
+
+    return {
+      importStatements: importStatements,
+      baseClass: baseClass,
+      firebaseUrl: firebaseUrl
+    };
+  }
+};

--- a/blueprints/firebase-adapter/index.js
+++ b/blueprints/firebase-adapter/index.js
@@ -1,24 +1,17 @@
 var inflection = require('inflection');
 
 module.exports = {
-  description: 'Generates an firebase adapter.',
+  description: 'Generates a firebase adapter.',
 
   locals: function(options) {
     var firebaseUrl     = 'config.firebase';
     var adapterName     = options.entity.name;
-    var baseClass       = 'FirebaseAdapter';
-    var importStatements =
-      'import config from \'../config/environment\';\n' +
-      'import Firebase from \'firebase\';\n' +
-      'import FirebaseAdapter from \'emberfire/adapters/firebase\';'
 
     if (adapterName !== 'application') {
       firebaseUrl = "config.firebase + '/" + inflection.pluralize(adapterName) + "'";
     }
 
     return {
-      importStatements: importStatements,
-      baseClass: baseClass,
       firebaseUrl: firebaseUrl
     };
   }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+added - The default generator overrides `config/environments.js`
+added - A blueprint for generating firebase adapters
 changed - Allow Ember Data versions `1.0.0.beta.11` through `beta.14.x`.
 fixed - Use `EnumerableUtils` methods for Ember configs with `EXTEND_PROTOTYPES` set to false.
 important - EmberFire uses es6 modules. Please check the documentation on updated usage info.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "gulp-es6-module-transpiler": "^0.2.1",
     "gulp-jshint": "^1.9.2",
     "gulp-sourcemaps": "^1.3.0",
-    "gulp-uglify": "^1.1.0"
+    "gulp-uglify": "^1.1.0",
+    "inflection": "^1.6.0"
   }
 }


### PR DESCRIPTION
- Generates `app/adapters/application.js` on addon install (or `ember g emberfire`). If an existing file exists you will have the opportunity to diff/decline the overwrite.
- Add blueprints `.jshintrc` and fix some linter errors
- `ember g emberfire` defaults the firebase url to `https://YOUR-FIREBASE-NAME.firebaseio.com/`
- Simplify the `ember g firebase-adapter`:
  - users unlikely to specify a base class (otherwise you'd use the normal `ember g adapter --base=blah`)
  - imports will likely never change

This puts the user in a very good position after a simple addon install. Something else I'd like to do is to `console.log` some text instructing the user to edit their `config/environment.js` file.
